### PR TITLE
Add icon URL option to all shipping methods

### DIFF
--- a/includes/methods/class-gls-shipping-method-parcel-locker-zones.php
+++ b/includes/methods/class-gls-shipping-method-parcel-locker-zones.php
@@ -22,10 +22,12 @@ function gls_shipping_method_parcel_locker_zones_init()
 
 				$this->supports = array('shipping-zones', 'instance-settings', 'instance-settings-modal');
 
-				$this->init();
+                                $this->init();
 
-				$this->enabled = isset($this->settings['enabled']) ? $this->settings['enabled'] : 'yes';
-				$this->title = isset($this->instance_settings['title']) ? $this->instance_settings['title'] : __('Delivery to GLC Parcel Locker', 'gls-shipping-for-woocommerce');
+                                $this->enabled  = isset($this->settings['enabled']) ? $this->settings['enabled'] : 'yes';
+                                $this->title    = isset($this->instance_settings['title']) ? $this->instance_settings['title'] : __('Delivery to GLC Parcel Locker', 'gls-shipping-for-woocommerce');
+                                $this->icon_url = isset($this->instance_settings['icon_url']) ? esc_url_raw($this->instance_settings['icon_url']) : '';
+                                $this->settings['icon_url'] = $this->icon_url;
 			}
 
 			/**
@@ -48,12 +50,20 @@ function gls_shipping_method_parcel_locker_zones_init()
 				$weight_unit = get_option('woocommerce_weight_unit');
 
 				$this->instance_form_fields = array(
-					'title' => array(
-						'title' => __('Title', 'gls-shipping-for-woocommerce'),
-						'type' => 'text',
-						'description' => __('Title to be displayed on site', 'gls-shipping-for-woocommerce'),
-						'default' => __('Delivery to GLS Parcel Locker', 'gls-shipping-for-woocommerce')
-					),
+                                        'title' => array(
+                                                'title' => __('Title', 'gls-shipping-for-woocommerce'),
+                                                'type' => 'text',
+                                                'description' => __('Title to be displayed on site', 'gls-shipping-for-woocommerce'),
+                                                'default' => __('Delivery to GLS Parcel Locker', 'gls-shipping-for-woocommerce')
+                                        ),
+                                        'icon_url' => array(
+                                                'title'       => __('Icon', 'gls-shipping-for-woocommerce'),
+                                                'type'        => 'text',
+                                                'description' => __('Image appears after the shipping name on cart and checkout pages.', 'gls-shipping-for-woocommerce'),
+                                                'default'     => '',
+                                                'desc_tip'    => true,
+                                                'sanitize_callback' => 'esc_url_raw',
+                                        ),
 					'shipping_price' => array(
 						'title'       => __('Shipping Price', 'gls-shipping-for-woocommerce'),
 						'type'        => 'text',

--- a/includes/methods/class-gls-shipping-method-parcel-locker.php
+++ b/includes/methods/class-gls-shipping-method-parcel-locker.php
@@ -18,10 +18,12 @@ function gls_shipping_method_parcel_locker_init()
 				$this->method_title       = __('GLS Parcel Locker', 'gls-shipping-for-woocommerce');
 				$this->method_description = __('Parcel Shop Delivery (PSD) service that ships parcels to the GLS Locker. GLS Parcel Locker can be selected from the interactive GLS Parcel Shop and GLS Locker finder map.', 'gls-shipping-for-woocommerce');
 
-				$this->init();
+                                $this->init();
 
-				$this->enabled = isset($this->settings['enabled']) ? $this->settings['enabled'] : 'yes';
-				$this->title = isset($this->settings['title']) ? $this->settings['title'] : __('Delivery to GLC Parcel Locker', 'gls-shipping-for-woocommerce');
+                                $this->enabled   = isset($this->settings['enabled']) ? $this->settings['enabled'] : 'yes';
+                                $this->title     = isset($this->settings['title']) ? $this->settings['title'] : __('Delivery to GLC Parcel Locker', 'gls-shipping-for-woocommerce');
+                                $this->icon_url  = isset($this->settings['icon_url']) ? esc_url_raw($this->settings['icon_url']) : '';
+                                $this->settings['icon_url'] = $this->icon_url;
 			}
 
 			/**
@@ -50,12 +52,20 @@ function gls_shipping_method_parcel_locker_init()
 						'description' => __('Enable this shipping globally.', 'gls-shipping-for-woocommerce'),
 						'default' => 'yes'
 					),
-					'title' => array(
-						'title' => __('Title', 'gls-shipping-for-woocommerce'),
-						'type' => 'text',
-						'description' => __('Title to be display on site', 'gls-shipping-for-woocommerce'),
-						'default' => __('Delivery to GLS Parcel Locker', 'gls-shipping-for-woocommerce')
-					),
+                                        'title' => array(
+                                                'title' => __('Title', 'gls-shipping-for-woocommerce'),
+                                                'type' => 'text',
+                                                'description' => __('Title to be display on site', 'gls-shipping-for-woocommerce'),
+                                                'default' => __('Delivery to GLS Parcel Locker', 'gls-shipping-for-woocommerce')
+                                        ),
+                                        'icon_url' => array(
+                                                'title'       => __('Icon', 'gls-shipping-for-woocommerce'),
+                                                'type'        => 'text',
+                                                'description' => __('Image appears after the shipping name on cart and checkout pages.', 'gls-shipping-for-woocommerce'),
+                                                'default'     => '',
+                                                'desc_tip'    => true,
+                                                'sanitize_callback' => 'esc_url_raw',
+                                        ),
 					'shipping_price' => array(
 						'title'       => __('Shipping Price', 'gls-shipping-for-woocommerce'),
 						'type'        => 'text',

--- a/includes/methods/class-gls-shipping-method-parcel-shop-zones.php
+++ b/includes/methods/class-gls-shipping-method-parcel-shop-zones.php
@@ -22,10 +22,12 @@ function gls_shipping_method_parcel_shop_zones_init()
 
 				$this->supports = array('shipping-zones', 'instance-settings', 'instance-settings-modal');
 
-				$this->init();
+                                $this->init();
 
-				$this->enabled = isset($this->settings['enabled']) ? $this->settings['enabled'] : 'yes';
-				$this->title = isset($this->instance_settings['title']) ? $this->instance_settings['title'] : __('Delivery to GLC Parcel Shop', 'gls-shipping-for-woocommerce');
+                                $this->enabled  = isset($this->settings['enabled']) ? $this->settings['enabled'] : 'yes';
+                                $this->title    = isset($this->instance_settings['title']) ? $this->instance_settings['title'] : __('Delivery to GLC Parcel Shop', 'gls-shipping-for-woocommerce');
+                                $this->icon_url = isset($this->instance_settings['icon_url']) ? esc_url_raw($this->instance_settings['icon_url']) : '';
+                                $this->settings['icon_url'] = $this->icon_url;
 			}
 
 			/**
@@ -48,12 +50,20 @@ function gls_shipping_method_parcel_shop_zones_init()
 				$weight_unit = get_option('woocommerce_weight_unit');
 
 				$this->instance_form_fields = array(
-					'title' => array(
-						'title' => __('Title', 'gls-shipping-for-woocommerce'),
-						'type' => 'text',
-						'description' => __('Title to be displayed on site', 'gls-shipping-for-woocommerce'),
-						'default' => __('Delivery to GLS Parcel Shop', 'gls-shipping-for-woocommerce')
-					),
+                                        'title' => array(
+                                                'title' => __('Title', 'gls-shipping-for-woocommerce'),
+                                                'type' => 'text',
+                                                'description' => __('Title to be displayed on site', 'gls-shipping-for-woocommerce'),
+                                                'default' => __('Delivery to GLS Parcel Shop', 'gls-shipping-for-woocommerce')
+                                        ),
+                                        'icon_url' => array(
+                                                'title'       => __('Icon', 'gls-shipping-for-woocommerce'),
+                                                'type'        => 'text',
+                                                'description' => __('Image appears after the shipping name on cart and checkout pages.', 'gls-shipping-for-woocommerce'),
+                                                'default'     => '',
+                                                'desc_tip'    => true,
+                                                'sanitize_callback' => 'esc_url_raw',
+                                        ),
 					'shipping_price' => array(
 						'title'       => __('Shipping Price', 'gls-shipping-for-woocommerce'),
 						'type'        => 'text',

--- a/includes/methods/class-gls-shipping-method-parcel-shop.php
+++ b/includes/methods/class-gls-shipping-method-parcel-shop.php
@@ -18,10 +18,12 @@ function gls_shipping_method_parcel_shop_init()
 				$this->method_title       = __('GLS Parcel Shop', 'gls-shipping-for-woocommerce');
 				$this->method_description = __('Parcel Shop Delivery (PSD) service that ships parcels to the GLS Parcel Shop. GLS Parcel Shop can be selected from the interactive GLS Parcel Shop and GLS Locker finder map.', 'gls-shipping-for-woocommerce');
 
-				$this->init();
+                                $this->init();
 
-				$this->enabled = isset($this->settings['enabled']) ? $this->settings['enabled'] : 'yes';
-				$this->title = isset($this->settings['title']) ? $this->settings['title'] : __('Delivery to GLC Parcel Shop', 'gls-shipping-for-woocommerce');
+                                $this->enabled   = isset($this->settings['enabled']) ? $this->settings['enabled'] : 'yes';
+                                $this->title     = isset($this->settings['title']) ? $this->settings['title'] : __('Delivery to GLC Parcel Shop', 'gls-shipping-for-woocommerce');
+                                $this->icon_url  = isset($this->settings['icon_url']) ? esc_url_raw($this->settings['icon_url']) : '';
+                                $this->settings['icon_url'] = $this->icon_url;
 			}
 
 			/**
@@ -50,12 +52,20 @@ function gls_shipping_method_parcel_shop_init()
 						'description' => __('Enable this shipping globally.', 'gls-shipping-for-woocommerce'),
 						'default' => 'yes'
 					),
-					'title' => array(
-						'title' => __('Title', 'gls-shipping-for-woocommerce'),
-						'type' => 'text',
-						'description' => __('Title to be display on site', 'gls-shipping-for-woocommerce'),
-						'default' => __('Delivery to GLS Parcel Shop', 'gls-shipping-for-woocommerce')
-					),
+                                        'title' => array(
+                                                'title' => __('Title', 'gls-shipping-for-woocommerce'),
+                                                'type' => 'text',
+                                                'description' => __('Title to be display on site', 'gls-shipping-for-woocommerce'),
+                                                'default' => __('Delivery to GLS Parcel Shop', 'gls-shipping-for-woocommerce')
+                                        ),
+                                        'icon_url' => array(
+                                                'title'       => __('Icon', 'gls-shipping-for-woocommerce'),
+                                                'type'        => 'text',
+                                                'description' => __('Image appears after the shipping name on cart and checkout pages.', 'gls-shipping-for-woocommerce'),
+                                                'default'     => '',
+                                                'desc_tip'    => true,
+                                                'sanitize_callback' => 'esc_url_raw',
+                                        ),
 					'shipping_price' => array(
 						'title'       => __('Shipping Price', 'gls-shipping-for-woocommerce'),
 						'type'        => 'text',

--- a/includes/methods/class-gls-shipping-method-zones.php
+++ b/includes/methods/class-gls-shipping-method-zones.php
@@ -22,10 +22,12 @@ function gls_shipping_method_zones_init()
 
 				$this->supports = array('shipping-zones', 'instance-settings', 'instance-settings-modal');
 
-				$this->init();
+                                $this->init();
 
-				$this->enabled = isset($this->settings['enabled']) ? $this->settings['enabled'] : 'yes';
-				$this->title = isset($this->instance_settings['title']) ? $this->instance_settings['title'] : __('Delivery to Address', 'gls-shipping-for-woocommerce');
+                                $this->enabled  = isset($this->settings['enabled']) ? $this->settings['enabled'] : 'yes';
+                                $this->title    = isset($this->instance_settings['title']) ? $this->instance_settings['title'] : __('Delivery to Address', 'gls-shipping-for-woocommerce');
+                                $this->icon_url = isset($this->instance_settings['icon_url']) ? esc_url_raw($this->instance_settings['icon_url']) : '';
+                                $this->settings['icon_url'] = $this->icon_url;
 			}
 
 			/**
@@ -48,12 +50,20 @@ function gls_shipping_method_zones_init()
 				$weight_unit = get_option('woocommerce_weight_unit');
 
 				$this->instance_form_fields = array(
-					'title' => array(
-						'title' => __('Title', 'gls-shipping-for-woocommerce'),
-						'type' => 'text',
-						'description' => __('Title to be displayed on site', 'gls-shipping-for-woocommerce'),
-						'default' => __('Delivery to Address', 'gls-shipping-for-woocommerce')
-					),
+                                        'title' => array(
+                                                'title' => __('Title', 'gls-shipping-for-woocommerce'),
+                                                'type' => 'text',
+                                                'description' => __('Title to be displayed on site', 'gls-shipping-for-woocommerce'),
+                                                'default' => __('Delivery to Address', 'gls-shipping-for-woocommerce')
+                                        ),
+                                        'icon_url' => array(
+                                                'title'       => __('Icon', 'gls-shipping-for-woocommerce'),
+                                                'type'        => 'text',
+                                                'description' => __('Image appears after the shipping name on cart and checkout pages.', 'gls-shipping-for-woocommerce'),
+                                                'default'     => '',
+                                                'desc_tip'    => true,
+                                                'sanitize_callback' => 'esc_url_raw',
+                                        ),
 					'shipping_price' => array(
 						'title'       => __('Shipping Price', 'gls-shipping-for-woocommerce'),
 						'type'        => 'text',

--- a/includes/methods/class-gls-shipping-method.php
+++ b/includes/methods/class-gls-shipping-method.php
@@ -20,10 +20,12 @@ function gls_shipping_method_init()
 				$this->method_title       = __('GLS Delivery to Address', 'gls-shipping-for-woocommerce');
 				$this->method_description = __('Parcels are shipped to the customer’s address.', 'gls-shipping-for-woocommerce');
 
-				$this->init();
+                                $this->init();
 
-				$this->enabled = isset($this->settings['enabled']) ? $this->settings['enabled'] : 'yes';
-				$this->title = isset($this->settings['title']) ? $this->settings['title'] : __('Delivery to Address', 'gls-shipping-for-woocommerce');
+                                $this->enabled   = isset($this->settings['enabled']) ? $this->settings['enabled'] : 'yes';
+                                $this->title     = isset($this->settings['title']) ? $this->settings['title'] : __('Delivery to Address', 'gls-shipping-for-woocommerce');
+                                $this->icon_url  = isset($this->settings['icon_url']) ? esc_url_raw($this->settings['icon_url']) : '';
+                                $this->settings['icon_url'] = $this->icon_url;
 			}
 
 			/**
@@ -62,12 +64,20 @@ function gls_shipping_method_init()
 						'description' => __('Enable this shipping globally.', 'gls-shipping-for-woocommerce'),
 						'default' => 'yes'
 					),
-					'title' => array(
-						'title' => __('Title', 'gls-shipping-for-woocommerce'),
-						'type' => 'text',
-						'description' => __('Title to be display on site', 'gls-shipping-for-woocommerce'),
-						'default' => __('Delivery to Address', 'gls-shipping-for-woocommerce')
-					),
+                                        'title' => array(
+                                                'title' => __('Title', 'gls-shipping-for-woocommerce'),
+                                                'type' => 'text',
+                                                'description' => __('Title to be display on site', 'gls-shipping-for-woocommerce'),
+                                                'default' => __('Delivery to Address', 'gls-shipping-for-woocommerce')
+                                        ),
+                                        'icon_url' => array(
+                                                'title'       => __('Icon', 'gls-shipping-for-woocommerce'),
+                                                'type'        => 'text',
+                                                'description' => __('Image appears after the shipping name on cart and checkout pages.', 'gls-shipping-for-woocommerce'),
+                                                'default'     => '',
+                                                'desc_tip'    => true,
+                                                'sanitize_callback' => 'esc_url_raw',
+                                        ),
 					'shipping_price' => array(
 						'title'       => __('Shipping Price', 'gls-shipping-for-woocommerce'),
 						'type'        => 'text',


### PR DESCRIPTION
## Summary
- add `icon_url` setting to each GLS shipping method
- sanitize saved URLs with `esc_url_raw`
- document that icons appear after the shipping name on cart and checkout pages

## Testing
- `php -l includes/methods/class-gls-shipping-method.php`
- `php -l includes/methods/class-gls-shipping-method-parcel-shop.php`
- `php -l includes/methods/class-gls-shipping-method-parcel-locker.php`
- `php -l includes/methods/class-gls-shipping-method-parcel-shop-zones.php`
- `php -l includes/methods/class-gls-shipping-method-parcel-locker-zones.php`
- `php -l includes/methods/class-gls-shipping-method-zones.php`


------
https://chatgpt.com/codex/tasks/task_e_68b702a0913c832889e54630a5f9f4bc