### PR TITLE
Add frontend CSS for GLS shipping icon

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -1,0 +1,6 @@
+/* Default styles for GLS shipping icon */
+.gls-shipping-icon {
+    width: 24px;
+    height: auto;
+    margin: 0 0.5em 0 0;
+}

--- a/includes/public/class-gls-shipping-assets.php
+++ b/includes/public/class-gls-shipping-assets.php
@@ -48,6 +48,7 @@ class GLS_Shipping_Assets
             'address' => __('Address', 'gls-shipping-for-woocommerce'),
             'country' => __('Country', 'gls-shipping-for-woocommerce'),
         );
+        wp_enqueue_style('gls-shipping-frontend', GLS_SHIPPING_URL . 'assets/css/frontend.css', array(), GLS_SHIPPING_VERSION);
         wp_enqueue_script('gls-shipping-dpm', 'https://map.gls-croatia.com/widget/gls-dpm.js', array(), GLS_SHIPPING_VERSION, false);
         wp_enqueue_script('gls-shipping-public', GLS_SHIPPING_URL . 'assets/js/gls-shipping-public.js', array('jquery', 'gls-shipping-dpm'), GLS_SHIPPING_VERSION, false);
         wp_localize_script(


### PR DESCRIPTION
## Summary
- add frontend stylesheet for `.gls-shipping-icon`
- enqueue new stylesheet with existing public assets

## Testing
- `php -l includes/public/class-gls-shipping-assets.php`
- `php -l gls-shipping-for-woocommerce.php`


------
https://chatgpt.com/codex/tasks/task_e_68b702a39a9c832890ac08d3680636fc