### PR TITLE
Load GLS icon URL from method settings

### DIFF
--- a/includes/public/class-gls-shipping-checkout.php
+++ b/includes/public/class-gls-shipping-checkout.php
@@ -90,14 +90,11 @@ class GLS_Shipping_Checkout
   
     public function decorate_shipping_label($label, $method)
     {
-        $icon_url = apply_filters('gls_shipping_method_icon_url', '', $method->get_method_id());
-        if (!empty($icon_url)) {
-            $label .= ' <img src="' . esc_url($icon_url) . '" alt="" />';
-        }
-
-        if (is_cart()) {
-            return $label;
-        }
+        $settings = get_option(
+            'woocommerce_' . $method->get_method_id() . '_' . $method->instance_id . '_settings',
+            []
+        );
+        $icon_url = isset($settings['icon_url']) ? $settings['icon_url'] : '';
 
         /**
          * Filter the URL of the GLS shipping method icon.
@@ -108,10 +105,21 @@ class GLS_Shipping_Checkout
          * @param string $url       Default icon URL. Empty by default.
          * @param string $method_id Shipping method ID.
          */
-        $icon_url = apply_filters('gls_shipping_method_icon_url', '', $method->id);
+        $icon_url = apply_filters('gls_shipping_method_icon_url', $icon_url, $method->get_method_id());
 
+        $icon = '';
         if (!empty($icon_url)) {
             $icon = '<img src="' . esc_url($icon_url) . '" alt="" class="gls-shipping-method-icon" style="height:1em;width:auto;margin-right:4px;vertical-align:middle;" />';
+        }
+
+        if (is_cart()) {
+            if (!empty($icon)) {
+                $label = $icon . $label;
+            }
+            return $label;
+        }
+
+        if (!empty($icon)) {
             $label = $icon . $label;
         }
 


### PR DESCRIPTION
## Summary
- load shipping method settings and icon URL in checkout label decorator
- pass configured icon URL through `gls_shipping_method_icon_url` filter before rendering
- show GLS icon before shipping label text on cart for consistent styling

## Testing
- `php -l includes/public/class-gls-shipping-checkout.php`


------
https://chatgpt.com/codex/tasks/task_e_68b70c14ad58832880d0b6c068e50375